### PR TITLE
Serde Serialize/Deserialize implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 **/*.rs.bk
 Cargo.lock
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,6 @@ script: |
 
 after_success: |
   if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
-    cargo tarpaulin --out Xml
+    cargo tarpaulin --all-features --out Xml
     bash <(curl -s https://codecov.io/bash)
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,14 @@ script: |
     cargo build;
     cargo build --no-default-features;
     cargo test;
+    cargo build --all-features
+    cargo test --all-features;
   else 
     cargo clean;
     cargo build;
     cargo test;
+    cargo build --all-features
+    cargo test --all-features;
   fi
 
 after_success: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ std = []
 [dependencies]
 cfg-if = "0.1"
 serde = { version = "1.0.89", optional = true }
+
+[dev-dependencies]
+serde_json = "1.0.39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ std = []
 
 [dependencies]
 cfg-if = "0.1"
+serde = { version = "1.0.89", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ std = []
 
 [dependencies]
 cfg-if = "0.1"
-serde = { version = "1.0.89", optional = true }
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.39"
+serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ To use `bimap-rs` in your Rust project, add the following to your `Cargo.toml`:
 bimap = "0.2"
 ```
 
+### `serde` compatibility
+
+`bimap-rs` optionally supports serialization and deserialization of `BiHashMap` and `BiBTreeMap`
+through [serde](https://serde.rs). To avoid unnecessary dependencies, this is gated behind the
+`serde` feature and must be manually enabled. To do so, add the following to your `Cargo.toml`:
+
+```toml
+bimap = { version = "0.2", features = [ "serde" ]} 
+```
+
 ### `no_std` compatibility
 
 To use `bimap-rs` without the Rust standard library, add the following to your `Cargo.toml`:
@@ -31,6 +41,7 @@ bimap = { version = "0.2", default-features = false }
 
 Note that you'll need to use Rust nightly due to the use of the `alloc` feature.
 If you do use `bimap` without the standard library, there is no `BiHashMap`, only `BiBTreeMap`.
+Currently, the `no_std` version of this library may not be used with `serde` integration.
 
 ### Example
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,9 @@ cfg_if::cfg_if! {
     }
 }
 
+#[cfg(feature = "serde")]
+pub mod serde;
+
 /// The previous left-right pairs, if any, that were overwritten by a call to the
 /// [`insert`](BiHashMap::insert) method of a bimap.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@ cfg_if::cfg_if! {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(all(feature = "serde", feature="std"))]
 pub mod serde;
 
 /// The previous left-right pairs, if any, that were overwritten by a call to the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,13 @@
 //! );
 //! ```
 //!
+//! ## serde compatibility
+//!
+//! When the `serde` feature is enabled, implementations of `Serialize` and
+//! `Deserialize` are provided for [`BiHashMap`] and [`BiBTreeMap`], allowing
+//! them to be serialized or deserialized painlessly. See the [`serde`] module
+//! for examples and more information.
+//!
 //! [bijective map]: https://en.wikipedia.org/wiki/Bijection
 //! [doesn't update an equal key upon insertion]:
 //! https://doc.rust-lang.org/std/collections/index.html#insert-and-complex-keys

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ cfg_if::cfg_if! {
     }
 }
 
-#[cfg(all(feature = "serde", feature="std"))]
+#[cfg(all(feature = "serde", feature = "std"))]
 pub mod serde;
 
 /// The previous left-right pairs, if any, that were overwritten by a call to the

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,105 @@
+//! Implementations of `serde::Serialize` and `serde::Deserialize` for
+//! `BiHashMap` and `BiBTreeMap`
+
+use crate::{BiHashMap, BiBTreeMap};
+use serde::{Serializer, Serialize, Deserializer, Deserialize};
+use serde::de::{Visitor, MapAccess};
+use std::hash::Hash;
+use std::fmt::{Formatter, Result as FmtResult};
+use std::marker::PhantomData;
+use std::default::Default;
+
+/// Serializer for `BiHashMap`
+impl<L, R> Serialize for BiHashMap<L, R>
+where
+    L: Serialize + Eq + Hash,
+    R: Serialize + Eq + Hash,
+{
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.collect_map(self.iter())
+    }
+}
+
+/// Visitor to construct `BiHashMap` from serialized map entries
+struct BiHashMapVisitor<L, R> {
+    marker: PhantomData<BiHashMap<L, R>>
+}
+
+impl<'de, L, R> Visitor<'de> for BiHashMapVisitor<L, R>
+where
+    L: Deserialize<'de> + Eq + Hash,
+    R: Deserialize<'de> + Eq + Hash,
+{
+    fn expecting(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "a map")
+    }
+
+    type Value = BiHashMap<L, R>;
+    fn visit_map<A: MapAccess<'de>>(self, mut entries: A) -> Result<Self::Value, A::Error> {
+        let mut map = match entries.size_hint() {
+            Some(s) => BiHashMap::with_capacity(s),
+            None => BiHashMap::new()
+        };
+        while let Some((l, r)) = entries.next_entry()? {
+            map.insert(l, r);
+        }
+        Ok(map)
+    }
+}
+
+/// Deserializer for `BiHashMap`
+impl<'de, L, R> Deserialize<'de> for BiHashMap<L, R>
+where
+    L: Deserialize<'de> + Eq + Hash,
+    R: Deserialize<'de> + Eq + Hash,
+{
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        de.deserialize_map(BiHashMapVisitor { marker: PhantomData::default() })
+    }
+}
+
+/// Serializer for `BiBTreeMap`
+impl<L, R> Serialize for BiBTreeMap<L, R>
+where
+    L: Serialize + Ord,
+    R: Serialize + Ord,
+{
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.collect_map(self.iter())
+    }
+}
+
+/// Visitor to construct `BiBTreeMap` from serialized map entries
+struct BiBTreeMapVisitor<L, R> {
+    marker: PhantomData<BiBTreeMap<L, R>>
+}
+
+impl<'de, L, R> Visitor<'de> for BiBTreeMapVisitor<L, R>
+where
+    L: Deserialize<'de> + Ord,
+    R: Deserialize<'de> + Ord,
+{
+    fn expecting(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "a map")
+    }
+
+    type Value = BiBTreeMap<L, R>;
+    fn visit_map<A: MapAccess<'de>>(self, mut entries: A) -> Result<Self::Value, A::Error> {
+        let mut map = BiBTreeMap::new();
+        while let Some((l, r)) = entries.next_entry()? {
+            map.insert(l, r);
+        }
+        Ok(map)
+    }
+}
+
+/// Deserializer for `BiBTreeMap`
+impl<'de, L, R> Deserialize<'de> for BiBTreeMap<L, R>
+where
+    L: Deserialize<'de> + Ord,
+    R: Deserialize<'de> + Ord,
+{
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        de.deserialize_map(BiBTreeMapVisitor { marker: PhantomData::default() })
+    }
+}

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -9,7 +9,7 @@
 //! # Examples
 //!
 //! You can easily serialize and deserialize bimaps with any serde-compatbile
-//! `serializer or deserializer.
+//! serializer or deserializer.
 //!
 //! Serializing and deserializing a [`BiHashMap`]:
 //!

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -3,14 +3,15 @@
 //!
 //! You do not need to import anything from this module to use this
 //! functionality, simply enable the `serde` feature in your dependency
-//! manifest.
+//! manifest. Note that currently, this requires the `std` feature to also be
+//! enabled, and thus cannot be used in `no_std` enviroments.
 //!
 //! # Examples
 //!
 //! You can easily serialize and deserialize bimaps with any serde-compatbile
 //! `serializer or deserializer.
 //!
-//! Serializing and deserializing a BiHashMap:
+//! Serializing and deserializing a [`BiHashMap`]:
 //!
 //! ```
 //! # use bimap::BiHashMap;
@@ -32,7 +33,7 @@
 //! assert_eq!(map, map2);
 //! ```
 //!
-//! Serializing and deserializing a BiBTreeMap:
+//! Serializing and deserializing a [`BiBTreeMap`]:
 //! ```
 //! # use bimap::BiBTreeMap;
 //! // create a new bimap
@@ -80,8 +81,8 @@
 //! implementation detail and should not be relied upon.*
 //!
 //! For example, a bimap can be deserialized from the serialized form of a
-//! standard hashmap. However, *deserializing a bimap silently overwrites any
-//! conflicting pairs*, leading to non-deterministic results.
+//! standard [`HashMap`]. However, *deserializing a bimap silently overwrites
+//! any conflicting pairs*, leading to non-deterministic results.
 //! ```
 //! # use std::collections::HashMap;
 //! # use bimap::BiHashMap;
@@ -113,7 +114,8 @@
 //! ```
 //!
 //! The reverse is also possible: bimaps may be serialized and then
-//! deserialized as other compatible types, such as a standard hashmap.
+//! deserialized as other compatible types, such as a [`HashMap`].
+//!
 //! ```
 //! # use std::collections::HashMap;
 //! # use bimap::BiHashMap;
@@ -138,6 +140,9 @@
 //! assert_eq!(map[&'B'], 2);
 //! assert_eq!(map[&'C'], 3);
 //! ```
+//! [`BiHashMap`]: crate::BiHashMap
+//! [`BiBTreeMap`]: crate::BiBTreeMap
+//! [`HashMap`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
 
 use crate::{BiHashMap, BiBTreeMap};
 use serde::{Serializer, Serialize, Deserializer, Deserialize};

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -121,7 +121,7 @@
 //! # use bimap::BiHashMap;
 //! // construct a bimap
 //! let mut bimap = BiHashMap::new();
-//! 
+//!
 //! // insert some pairs
 //! bimap.insert('A', 1);
 //! bimap.insert('B', 2);
@@ -144,13 +144,13 @@
 //! [`BiBTreeMap`]: crate::BiBTreeMap
 //! [`HashMap`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
 
-use crate::{BiHashMap, BiBTreeMap};
-use serde::{Serializer, Serialize, Deserializer, Deserialize};
-use serde::de::{Visitor, MapAccess};
-use std::hash::Hash;
-use std::fmt::{Formatter, Result as FmtResult};
-use std::marker::PhantomData;
+use crate::{BiBTreeMap, BiHashMap};
+use serde::de::{MapAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::default::Default;
+use std::fmt::{Formatter, Result as FmtResult};
+use std::hash::Hash;
+use std::marker::PhantomData;
 
 /// Serializer for `BiHashMap`
 impl<L, R> Serialize for BiHashMap<L, R>
@@ -165,7 +165,7 @@ where
 
 /// Visitor to construct `BiHashMap` from serialized map entries
 struct BiHashMapVisitor<L, R> {
-    marker: PhantomData<BiHashMap<L, R>>
+    marker: PhantomData<BiHashMap<L, R>>,
 }
 
 impl<'de, L, R> Visitor<'de> for BiHashMapVisitor<L, R>
@@ -181,7 +181,7 @@ where
     fn visit_map<A: MapAccess<'de>>(self, mut entries: A) -> Result<Self::Value, A::Error> {
         let mut map = match entries.size_hint() {
             Some(s) => BiHashMap::with_capacity(s),
-            None => BiHashMap::new()
+            None => BiHashMap::new(),
         };
         while let Some((l, r)) = entries.next_entry()? {
             map.insert(l, r);
@@ -197,7 +197,9 @@ where
     R: Deserialize<'de> + Eq + Hash,
 {
     fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
-        de.deserialize_map(BiHashMapVisitor { marker: PhantomData::default() })
+        de.deserialize_map(BiHashMapVisitor {
+            marker: PhantomData::default(),
+        })
     }
 }
 
@@ -214,7 +216,7 @@ where
 
 /// Visitor to construct `BiBTreeMap` from serialized map entries
 struct BiBTreeMapVisitor<L, R> {
-    marker: PhantomData<BiBTreeMap<L, R>>
+    marker: PhantomData<BiBTreeMap<L, R>>,
 }
 
 impl<'de, L, R> Visitor<'de> for BiBTreeMapVisitor<L, R>
@@ -243,7 +245,9 @@ where
     R: Deserialize<'de> + Ord,
 {
     fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
-        de.deserialize_map(BiBTreeMapVisitor { marker: PhantomData::default() })
+        de.deserialize_map(BiBTreeMapVisitor {
+            marker: PhantomData::default(),
+        })
     }
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -254,6 +254,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde::de::value::Error;
 
     #[test]
     fn serde_hash() {
@@ -279,5 +280,25 @@ mod tests {
         let bimap2 = serde_json::from_str(&json).unwrap();
 
         assert_eq!(bimap, bimap2);
+    }
+
+    #[test]
+    fn expecting_btree() {
+        let visitor = BiBTreeMapVisitor {
+            marker: PhantomData::<BiBTreeMap<char, i32>>,
+        };
+        let error_str = format!("{:?}", visitor.visit_bool::<Error>(true));
+        let expected = "Err(Error { err: \"invalid type: boolean `true`, expected a map\" })";
+        assert_eq!(error_str, expected);
+    }
+
+    #[test]
+    fn expecting_hash() {
+        let visitor = BiHashMapVisitor {
+            marker: PhantomData::<BiHashMap<char, i32>>,
+        };
+        let error_str = format!("{:?}", visitor.visit_bool::<Error>(true));
+        let expected = "Err(Error { err: \"invalid type: boolean `true`, expected a map\" })";
+        assert_eq!(error_str, expected);
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,5 +1,110 @@
 //! Implementations of `serde::Serialize` and `serde::Deserialize` for
-//! `BiHashMap` and `BiBTreeMap`
+//! `BiHashMap` and `BiBTreeMap`.
+//!
+//! You do not need to import anything from this module to use this
+//! functionality, simply enable the `serde` feature in your dependency
+//! manifest.
+//!
+//! # Examples
+//!
+//! You can easily serialize and deserialize bimaps with any serde-compatbile
+//! `serializer or deserializer.
+//!
+//! Serializing and deserializing a BiHashMap:
+//!
+//! ```
+//! # use bimap::BiHashMap;
+//! // create a new bimap
+//! let mut map = BiHashMap::new();
+//!
+//! // insert some pairs
+//! map.insert("A", 1);
+//! map.insert("B", 2);
+//! map.insert("C", 3);
+//!
+//! // convert the bimap to json
+//! let json = serde_json::to_string(&map).unwrap();
+//!
+//! // convert the json back into a bimap
+//! let map2 = serde_json::from_str(&json).unwrap();
+//!
+//! // check that the two bimaps are equal
+//! assert_eq!(map, map2);
+//! ```
+//!
+//! Serializing and deserializing a BiBTreeMap:
+//! ```
+//! # use bimap::BiBTreeMap;
+//! // create a new bimap
+//! let mut map = BiBTreeMap::new();
+//!
+//! // insert some pairs
+//! map.insert(1, 3);
+//! map.insert(2, 2);
+//! map.insert(3, 1);
+//!
+//! // convert the bimap to json
+//! let json = serde_json::to_string(&map).unwrap();
+//!
+//! // convert the json back into a bimap
+//! let map2 = serde_json::from_str(&json).unwrap();
+//!
+//! // check that the two bimaps are equal
+//! assert_eq!(map, map2);
+//! ```
+//!
+//! Of course, this is only possible for bimaps where the values also implement
+//! `Serialize` and `Deserialize` respectively:
+//!
+//! ```compile_fail
+//! # use bimap::BiHashMap;
+//! // this type doesn't implement Serialize or Deserialize!
+//! #[derive(PartialEq, Eq, Hash)]
+//! enum MyEnum { A, B, C }
+//!
+//! // create a bimap and add some pairs
+//! let mut map = BiHashMap::new();
+//! map.insert(MyEnum::A, 1);
+//! map.insert(MyEnum::B, 2);
+//! map.insert(MyEnum::C, 3);
+//!
+//! // this line will cause the code to fail to compile
+//! let json = serde_json::to_string(&map).unwrap();
+//! ```
+//!
+//! Although possible, deserializing a bimap from a serialized form that was
+//! not originally a bimap is not recommended or supported. Deserialization of
+//! a bimap silently overwrites any pairs where either value is already stored,
+//! and this can cause undefined behavior.
+//! ```
+//! # use std::collections::HashMap;
+//! # use bimap::BiHashMap;
+//! // construct a regular map
+//! let mut map = HashMap::new();
+//!
+//! // insert some entries
+//! // note that both "B" and "C" are associated with the value 2 here
+//! map.insert("A", 1);
+//! map.insert("B", 2);
+//! map.insert("C", 2);
+//!
+//! // serialize the map
+//! let json = serde_json::to_string(&map).unwrap();
+//!
+//! // deserialize it into a bimap
+//! let bimap: BiHashMap<&str, i32> = serde_json::from_str(&json).unwrap();
+//!
+//! // deserialization succeeds, but the bimap is now in a non-deterministic
+//! // state - either ("B", 2) or ("C", 2) will have been overwritten while
+//! // deserializing, but this depends on the iteration order of the original
+//! // HashMap that was serialized.
+//!
+//! // we can still demonstrate that certain properties of the bimap are still
+//! // in a known state
+//! assert_eq!(bimap.len(), 2);
+//! assert_eq!(bimap.get_by_left(&"A"), Some(&1));
+//! assert!(bimap.get_by_left(&"B") == Some(&2) || bimap.get_by_left(&"C") == Some(&2))
+//! ```
 
 use crate::{BiHashMap, BiBTreeMap};
 use serde::{Serializer, Serialize, Deserializer, Deserialize};


### PR DESCRIPTION
This PR adds implementations of `serde::Serialize` and `serde::Deserialize` for `BiHashMap` and `BiBTreeMap`, gated behind the `serde` and `std` features.

Progress:
- [x] Implementations of `Serialize` and `Deserialize`
- [x] Documentation with examples
- [x] Unit tests
- [x] Update README/crate documentation