### PR TITLE
Store hashmap values in a single Vec instead of Rc's

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,8 +2,8 @@
 
 extern crate test;
 
-use test::{Bencher, black_box};
 use bimap::BiHashMap;
+use test::{black_box, Bencher};
 
 #[bench]
 fn bench_hash_map_insert(b: &mut Bencher) {
@@ -12,6 +12,19 @@ fn bench_hash_map_insert(b: &mut Bencher) {
 
         for i in 1i64..100 {
             map.insert(format!("key {}", i), i);
+        }
+
+        black_box(map);
+    });
+}
+
+#[bench]
+fn bench_hash_map_insert_no_overwrite(b: &mut Bencher) {
+    b.iter(|| {
+        let mut map: BiHashMap<String, i64> = BiHashMap::new();
+
+        for i in 1i64..100 {
+            let _ = map.insert_no_overwrite(format!("key {}", i), i);
         }
 
         black_box(map);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,144 @@
+#![feature(test)]
+
+extern crate test;
+
+use test::{Bencher, black_box};
+use bimap::BiHashMap;
+
+#[bench]
+fn bench_hash_map_insert(b: &mut Bencher) {
+    b.iter(|| {
+        let mut map: BiHashMap<String, i64> = BiHashMap::new();
+
+        for i in 1i64..100 {
+            map.insert(format!("key {}", i), i);
+        }
+
+        black_box(map);
+    });
+}
+
+#[bench]
+fn bench_hash_map_get_left(b: &mut Bencher) {
+    let mut map: BiHashMap<String, i64> = BiHashMap::new();
+
+    for i in 1i64..100 {
+        map.insert(format!("key {}", i), i);
+    }
+
+    b.iter(|| {
+        for i in 1i64..100 {
+            black_box(map.get_by_left(&format!("key {}", i)));
+        }
+    });
+}
+
+#[bench]
+fn bench_hash_map_get_right(b: &mut Bencher) {
+    let mut map: BiHashMap<String, i64> = BiHashMap::new();
+
+    for i in 1i64..100 {
+        map.insert(format!("key {}", i), i);
+    }
+
+    b.iter(|| {
+        for i in 1i64..100 {
+            black_box(map.get_by_right(&i));
+        }
+    });
+}
+
+#[bench]
+fn bench_hash_map_iter(b: &mut Bencher) {
+    let mut map: BiHashMap<String, i64> = BiHashMap::new();
+
+    for i in 1i64..100 {
+        map.insert(format!("key {}", i), i);
+    }
+
+    b.iter(|| {
+        map.iter().for_each(|(l, r)| {
+            black_box((l, r));
+        });
+    });
+}
+
+#[bench]
+fn bench_hash_map_replace_right(b: &mut Bencher) {
+    let mut map: BiHashMap<String, i64> = BiHashMap::new();
+
+    for i in 1i64..100 {
+        map.insert(format!("key {}", i), i);
+    }
+
+    let mut y = 0;
+
+    b.iter(|| {
+        for i in 1i64..100 {
+            black_box(map.insert(format!("key {}", i), y + i));
+        }
+
+        assert_eq!(map.len(), 99);
+
+        y += 100;
+    });
+}
+
+#[bench]
+fn bench_hash_map_replace_left(b: &mut Bencher) {
+    let mut map: BiHashMap<String, i64> = BiHashMap::new();
+
+    for i in 1i64..100 {
+        map.insert(format!("key {}", i), i);
+    }
+
+    let mut y = 0;
+
+    b.iter(|| {
+        for i in 1i64..100 {
+            black_box(map.insert(format!("key {}", y + i), i));
+        }
+
+        assert_eq!(map.len(), 99);
+
+        y += 100;
+    });
+}
+
+#[bench]
+fn bench_hash_map_replace_both(b: &mut Bencher) {
+    let mut map: BiHashMap<String, i64> = BiHashMap::new();
+
+    for i in 1i64..100 {
+        map.insert(format!("key {}", i), i);
+    }
+
+    let mut order = true;
+
+    b.iter(|| {
+        for i in 1i64..100 {
+            black_box(map.insert(format!("key {}", i), if order { i } else { 100 - i }));
+        }
+
+        assert_eq!(map.len(), 99);
+
+        order = !order;
+    });
+}
+
+#[bench]
+fn bench_hash_map_replace_same(b: &mut Bencher) {
+    let mut map: BiHashMap<String, i64> = BiHashMap::new();
+
+    for i in 1i64..100 {
+        map.insert(format!("key {}", i), i);
+    }
+
+    b.iter(|| {
+        for i in 1i64..100 {
+            black_box(map.insert(format!("key {}", i), i));
+        }
+
+        assert_eq!(map.len(), 99);
+    });
+}

--- a/src/btree.rs
+++ b/src/btree.rs
@@ -21,7 +21,7 @@ cfg_if::cfg_if! {
 }
 
 /// A bimap backed by two `BTreeMap`s.
-/// 
+///
 /// See the [module-level documentation] for more details and examples.
 ///
 /// [module-level documentation]: crate
@@ -661,8 +661,18 @@ impl<'a, L, R> Iterator for RightValues<'a, L, R> {
 
 // safe because internal Rcs are not exposed by the api and the reference counts only change in
 // methods with &mut self
-unsafe impl<L, R> Send for BiBTreeMap<L, R> where L: Send, R: Send {}
-unsafe impl<L, R> Sync for BiBTreeMap<L, R> where L: Sync, R: Sync {}
+unsafe impl<L, R> Send for BiBTreeMap<L, R>
+where
+    L: Send,
+    R: Send,
+{
+}
+unsafe impl<L, R> Sync for BiBTreeMap<L, R>
+where
+    L: Sync,
+    R: Sync,
+{
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,6 @@
 //! [`insert_no_overwrite`]: BiHashMap::insert_no_overwrite
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,8 +170,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-//cfg_if::cfg_if! {
-//    if #[cfg(feature = "std")] {
+cfg_if::cfg_if! {
+    if #[cfg(feature = "std")] {
         pub mod btree;
         pub mod hash;
 
@@ -179,17 +179,17 @@
         pub type BiMap<L, R> = BiHashMap<L, R>;
 
         pub use self::{btree::BiBTreeMap, hash::BiHashMap};
-//    } else {
-//        extern crate alloc;
-//
-//        pub mod btree;
-//
-//        /// Type definition for convenience and compatibility with older versions of this crate.
-//        pub type BiMap<L, R> = BiBTreeMap<L, R>;
-//
-//        pub use self::btree::BiBTreeMap;
-//    }
-//}
+    } else {
+        extern crate alloc;
+
+        pub mod btree;
+
+        /// Type definition for convenience and compatibility with older versions of this crate.
+        pub type BiMap<L, R> = BiBTreeMap<L, R>;
+
+        pub use self::btree::BiBTreeMap;
+    }
+}
 
 #[cfg(all(feature = "serde", feature = "std"))]
 pub mod serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,8 +170,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
+//cfg_if::cfg_if! {
+//    if #[cfg(feature = "std")] {
         pub mod btree;
         pub mod hash;
 
@@ -179,17 +179,17 @@ cfg_if::cfg_if! {
         pub type BiMap<L, R> = BiHashMap<L, R>;
 
         pub use self::{btree::BiBTreeMap, hash::BiHashMap};
-    } else {
-        extern crate alloc;
-
-        pub mod btree;
-
-        /// Type definition for convenience and compatibility with older versions of this crate.
-        pub type BiMap<L, R> = BiBTreeMap<L, R>;
-
-        pub use self::btree::BiBTreeMap;
-    }
-}
+//    } else {
+//        extern crate alloc;
+//
+//        pub mod btree;
+//
+//        /// Type definition for convenience and compatibility with older versions of this crate.
+//        pub type BiMap<L, R> = BiBTreeMap<L, R>;
+//
+//        pub use self::btree::BiBTreeMap;
+//    }
+//}
 
 #[cfg(all(feature = "serde", feature = "std"))]
 pub mod serde;


### PR DESCRIPTION
This stores all the value pairs in a Vec and keeps 2 HashMaps that hold indexes into the Vec to allow lookups.

This trades the overhead from Rc with the overhead of using the index, note that in both cases the HashMaps hold "pointers" to the values.

On my local machine the added benchmarks give the following result

before:

    test bench_hash_map_get_left            ... bench:       8,294 ns/iter (+/- 724)
    test bench_hash_map_get_right           ... bench:       2,094 ns/iter (+/- 286)
    test bench_hash_map_insert              ... bench:      34,270 ns/iter (+/- 1,634)
    test bench_hash_map_insert_no_overwrite ... bench:      33,936 ns/iter (+/- 4,649)
    test bench_hash_map_iter                ... bench:         320 ns/iter (+/- 47)
    test bench_hash_map_replace_both        ... bench:      27,046 ns/iter (+/- 2,294)
    test bench_hash_map_replace_left        ... bench:      35,141 ns/iter (+/- 2,200)
    test bench_hash_map_replace_right       ... bench:      31,532 ns/iter (+/- 2,925)
    test bench_hash_map_replace_same        ... bench:      23,992 ns/iter (+/- 1,224)

after:

    test bench_hash_map_get_left            ... bench:       7,807 ns/iter (+/- 1,015)
    test bench_hash_map_get_right           ... bench:       2,195 ns/iter (+/- 321)
    test bench_hash_map_insert              ... bench:      16,577 ns/iter (+/- 1,068)
    test bench_hash_map_insert_no_overwrite ... bench:      15,947 ns/iter (+/- 1,006)
    test bench_hash_map_iter                ... bench:          66 ns/iter (+/- 7)
    test bench_hash_map_replace_both        ... bench:      16,406 ns/iter (+/- 1,372)
    test bench_hash_map_replace_left        ... bench:      21,219 ns/iter (+/- 2,122)
    test bench_hash_map_replace_right       ... bench:      18,556 ns/iter (+/- 1,374)
    test bench_hash_map_replace_same        ... bench:      11,585 ns/iter (+/- 1,510)

Getting values is pretty much the same since both have one layer of indirection on top of the HashMap.
Inserting is ~30% faster, presumably due to not having to create the Rc's.
Iterating is a lot faster presumably due the cache locality of the values in the new setup.

Memory overhead should be less -- the Rc adds 2 usize's overhead per stored item for refcounting, both implementations store 2 "pointers" per value in the HashMaps) -- but I don't have proper numbers on that.

Since the keys stored in the new HashMaps are themselves already hashes of the inserted values, a dummy hasher is used to prevent double hashing.