### PR TITLE
Allow using alternate hashers with BiHashMap

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -883,6 +883,16 @@ mod tests {
     }
 
     #[test]
+    fn with_hashers() {
+        let s_left = hash_map::RandomState::new();
+        let s_right = hash_map::RandomState::new();
+        let mut bimap = BiHashMap::<char, i32>::with_hashers(s_left, s_right);
+        bimap.insert('a', 42);
+        assert_eq!(Some(&'a'), bimap.get_by_right(&42));
+        assert_eq!(Some(&42), bimap.get_by_left(&'a'));
+    }
+
+    #[test]
     fn clear() {
         let mut bimap = vec![('a', 1)].into_iter().collect::<BiHashMap<_, _>>();
         assert_eq!(bimap.len(), 1);

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -522,11 +522,19 @@ impl<L, R, LS, RS> Clone for BiHashMap<L, R, LS, RS>
 where
     L: Clone + Eq + Hash,
     R: Clone + Eq + Hash,
-    LS: BuildHasher + Default,
-    RS: BuildHasher + Default,
+    LS: BuildHasher + Clone,
+    RS: BuildHasher + Clone,
 {
     fn clone(&self) -> BiHashMap<L, R, LS, RS> {
-        self.iter().map(|(l, r)| (l.clone(), r.clone())).collect()
+        let mut new_bimap = BiHashMap::with_capacity_and_hashers(
+            self.capacity(),
+            self.left2right.hasher().clone(),
+            self.right2left.hasher().clone(),
+        );
+        for (l, r) in self.iter() {
+            new_bimap.insert(l.clone(), r.clone());
+        }
+        new_bimap
     }
 }
 


### PR DESCRIPTION
With std `HashMap`, it's possible to use an alternate hasher, for example [fnv](https://crates.io/crates/fnv), instead of the default SipHash, by passing a third type parameter: `HashMap<K, V, FnvBuildHasher>`. This is often desired for performance reasons, when keys are small and not malicious. This is not currently possible with `BiHashMap`.

## Changes

This PR changes the definition to `BiHashMap<L, R, LS = RandomState, RS = RandomState>` to allow this, with `LS` and `RS` being the hash builders for `L` and `R`, respectively. The `BiMap` alias is not changed, because it has to match the `BiBTreeMap` version.

- Functions are grouped into impl blocks with different bounds matching those of `HashMap`.
- `with_hasher` constructors are added.
- Bounds on the new parameters are added to trait impls, mostly matching `HashMap` with the exception of `Clone`, where `Default` is required instead of `Clone`, due to the way the trait is implemented.

## Compatibility

Strictly speaking, this should be considered a breaking change.

Although adding defaulted type parameters are considered non-breaking according to [RFC 1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md#minor-change-adding-defaulted-type-parameters), in practice, the change does break some direct invocations of `from_iter`, requiring type annotations for `LS` and `RS`, when they can't be inferred from usage (e.g. function signature or a struct field).

As a reference, type annotations are also required when the standard `HashMap::from_iter` is called directly. Such annotations are not required when using `collect`, which is the preferred way of using `FromIterator` according to [the docs](https://doc.rust-lang.org/std/iter/trait.FromIterator.html).

Please consider whether a minor version bump would be needed, in case this is merged.