### PR TITLE
Implement std::iter::Extend for BiHashMap and BiBTreeMap

### DIFF
--- a/src/btree.rs
+++ b/src/btree.rs
@@ -7,14 +7,14 @@ cfg_if::cfg_if! {
             cmp::Ordering,
             collections::{btree_map, BTreeMap},
             fmt,
-            iter::{FromIterator, FusedIterator},
+            iter::{Extend, FromIterator, FusedIterator},
             rc::Rc,
         };
     } else {
         use core::{
             cmp::Ordering,
             fmt,
-            iter::{FromIterator, FusedIterator},
+            iter::{Extend, FromIterator, FusedIterator},
         };
         use alloc::{collections::{btree_map, BTreeMap }, rc::Rc};
     }
@@ -497,6 +497,18 @@ where
     }
 }
 
+impl<L, R> Extend<(L, R)> for BiBTreeMap<L, R>
+where
+    L: Ord,
+    R: Ord,
+{
+    fn extend<T: IntoIterator<Item = (L, R)>>(&mut self, iter: T) {
+        iter.into_iter().for_each(move |(l, r)| {
+            self.insert(l, r);
+        });
+    }
+}
+
 impl<L, R> Ord for BiBTreeMap<L, R>
 where
     L: Ord,
@@ -771,6 +783,19 @@ mod tests {
         bimap.insert('c', 1);
         let pairs = (&bimap).into_iter().collect::<Vec<_>>();
         assert_eq!(pairs, vec![(&'a', &3), (&'b', &2), (&'c', &1)]);
+    }
+
+    #[test]
+    fn extend() {
+        let mut bimap = BiBTreeMap::new();
+        bimap.insert('a', 3);
+        bimap.insert('b', 2);
+        bimap.extend(vec![('c', 3), ('b', 1), ('a', 4)]);
+        let mut bimap2 = BiBTreeMap::new();
+        bimap2.insert('a', 4);
+        bimap2.insert('b', 1);
+        bimap2.insert('c', 3);
+        assert_eq!(bimap, bimap2);
     }
 
     #[test]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -5,7 +5,7 @@ use std::{
     collections::{hash_map, HashMap},
     fmt,
     hash::{BuildHasher, Hash},
-    iter::{FromIterator, FusedIterator},
+    iter::{Extend, FromIterator, FusedIterator},
     ops::Deref,
     rc::Rc,
 };
@@ -636,6 +636,20 @@ where
     }
 }
 
+impl<L, R, LS, RS> Extend<(L, R)> for BiHashMap<L, R, LS, RS>
+where
+    L: Eq + Hash,
+    R: Eq + Hash,
+    LS: BuildHasher,
+    RS: BuildHasher,
+{
+    fn extend<T: IntoIterator<Item = (L, R)>>(&mut self, iter: T) {
+        iter.into_iter().for_each(move |(l, r)| {
+            self.insert(l, r);
+        });
+    }
+}
+
 impl<L, R, LS, RS> PartialEq for BiHashMap<L, R, LS, RS>
 where
     L: Eq + Hash,
@@ -872,6 +886,19 @@ mod tests {
         let mut pairs = (&bimap).into_iter().collect::<Vec<_>>();
         pairs.sort();
         assert_eq!(pairs, vec![(&'a', &3), (&'b', &2), (&'c', &1)]);
+    }
+
+    #[test]
+    fn extend() {
+        let mut bimap = BiHashMap::new();
+        bimap.insert('a', 3);
+        bimap.insert('b', 2);
+        bimap.extend(vec![('c', 3), ('b', 1), ('a', 4)]);
+        let mut bimap2 = BiHashMap::new();
+        bimap2.insert('a', 4);
+        bimap2.insert('b', 1);
+        bimap2.insert('c', 3);
+        assert_eq!(bimap, bimap2);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,9 +131,9 @@
 //! );
 //! ```
 //!
-//! Note that the `FromIterator` implementations for both `BiHashMap` and `BiBTreeMap` use the
-//! `insert` method internally, meaning that values from the original iterator can be silently
-//! overwritten.
+//! Note that the `FromIterator` and `Extend` implementations for both `BiHashMap` and `BiBTreeMap`
+//! use the `insert` method internally, meaning that values from the original iterator/collection
+//! can be silently overwritten.
 //!
 //! ```
 //! use bimap::BiMap;


### PR DESCRIPTION
This PR includes an implementation of Extend for both bimaps.

Closes #11 