### PR TITLE
fix no_std tests for BiBTreeMap

### DIFF
--- a/src/btree.rs
+++ b/src/btree.rs
@@ -678,6 +678,9 @@ where
 mod tests {
     use super::*;
 
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
+
     #[test]
     fn clone() {
         let mut bimap = BiBTreeMap::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@
 //!
 //! ```
 //! use bimap::{BiMap, Overwritten};
+//! use std::cmp::Ordering;
 //! use std::hash::{Hash, Hasher};
 //!
 //! #[derive(Clone, Copy, Debug)]
@@ -94,6 +95,19 @@
 //! }
 //!
 //! impl Eq for Foo {}
+//!
+//! impl PartialOrd for Foo {
+//!     fn partial_cmp(&self, other: &Foo) -> Option<Ordering> {
+//!         Some(self.cmp(other))
+//!     }
+//! }
+//!
+//! // ordering only depends on the important data
+//! impl Ord for Foo {
+//!     fn cmp(&self, other: &Foo) -> Ordering {
+//!         self.important.cmp(&other.important)
+//!     }
+//! }
 //!
 //! // hash only depends on the important data
 //! impl Hash for Foo {
@@ -180,6 +194,11 @@ cfg_if::cfg_if! {
 
         pub use self::{btree::BiBTreeMap, hash::BiHashMap};
     } else {
+        #[cfg(test)]
+        #[macro_use]
+        extern crate alloc;
+
+        #[cfg(not(test))]
         extern crate alloc;
 
         pub mod btree;


### PR DESCRIPTION
From my other pull request (#12), I noticed that the `no_std` tests were failing to run for BiBTreeMap.

To fix this, I've imported alloc guarded by `cfg(test)`, allowing the unit tests to run.

I've also modified a failing doctest in `lib.rs`, which required `Ord` to be implemented for `Foo`.