### PR TITLE
Implement pretty debug formatting

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -547,13 +547,28 @@ where
     R: fmt::Debug + Eq + Hash,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{{")?;
-        for (i, (left, right)) in self.left2right.iter().enumerate() {
-            let comma = if i == 0 { "" } else { ", " };
-            write!(f, "{}{:?} <> {:?}", comma, left, right)?;
+        struct EntryDebugger<'a, L, R> {
+            left: &'a L,
+            right: &'a R,
         }
-        write!(f, "}}")?;
-        Ok(())
+        impl<'a, L, R> fmt::Debug for EntryDebugger<'a, L, R>
+        where
+            L: fmt::Debug,
+            R: fmt::Debug,
+        {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                self.left.fmt(f)?;
+                write!(f, " <> ")?;
+                self.right.fmt(f)
+            }
+        }
+        f.debug_set()
+            .entries(
+                self.left2right
+                    .iter()
+                    .map(|(left, right)| EntryDebugger { left, right }),
+            )
+            .finish()
     }
 }
 


### PR DESCRIPTION
I've implemented pretty debug formatting. It uses `fmt::DebugSet` with an intermediate `EnntryDebugger` struct and makes no assumptions about the formatter. It also retains the `<>` bidirectional relationship symbol for each entry.