### PR TITLE
Remove cfg-if dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ default = ["std"]
 std = []
 
 [dependencies]
-cfg-if = "0.1"
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/src/btree.rs
+++ b/src/btree.rs
@@ -1,24 +1,15 @@
 //! A bimap backed by two `BTreeMap`s.
 
 use crate::Overwritten;
-cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
-        use std::{
-            cmp::Ordering,
-            collections::{btree_map, BTreeMap},
-            fmt,
-            iter::{Extend, FromIterator, FusedIterator},
-            rc::Rc,
-        };
-    } else {
-        use core::{
-            cmp::Ordering,
-            fmt,
-            iter::{Extend, FromIterator, FusedIterator},
-        };
-        use alloc::{collections::{btree_map, BTreeMap }, rc::Rc};
-    }
-}
+use alloc::{
+    collections::{btree_map, BTreeMap},
+    rc::Rc,
+};
+use core::{
+    cmp::Ordering,
+    fmt,
+    iter::{Extend, FromIterator, FusedIterator},
+};
 
 /// A bimap backed by two `BTreeMap`s.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,31 +184,25 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
-        pub mod btree;
-        pub mod hash;
+// Necessary to support no_std setups
+#[allow(unused_imports)]
+#[macro_use]
+extern crate alloc;
 
-        /// Type definition for convenience and compatibility with older versions of this crate.
-        pub type BiMap<L, R> = BiHashMap<L, R>;
+pub mod btree;
+pub use btree::BiBTreeMap;
 
-        pub use self::{btree::BiBTreeMap, hash::BiHashMap};
-    } else {
-        #[cfg(test)]
-        #[macro_use]
-        extern crate alloc;
+#[cfg(feature = "std")]
+pub mod hash;
+#[cfg(feature = "std")]
+pub use hash::BiHashMap;
 
-        #[cfg(not(test))]
-        extern crate alloc;
+/// Type definition for convenience and compatibility with older versions of this crate.
+#[cfg(feature = "std")]
+pub type BiMap<L, R> = BiHashMap<L, R>;
 
-        pub mod btree;
-
-        /// Type definition for convenience and compatibility with older versions of this crate.
-        pub type BiMap<L, R> = BiBTreeMap<L, R>;
-
-        pub use self::btree::BiBTreeMap;
-    }
-}
+#[cfg(not(feature = "std"))]
+pub type BiMap<L, R> = BiBTreeMap<L, R>;
 
 #[cfg(all(feature = "serde", feature = "std"))]
 pub mod serde;


### PR DESCRIPTION
`cfg-if` makes the code a bit more readable, but it's only used in two places. It can be easily replaced with `#[cfg(...)]`, removing the only required dependency for the project and even shaving off a few lines.

I realize that this is an opinionated change, and while it would be nice to have zero dependencies, the readability improvement may be worth it, especially considering that `cfg-if` is a small crate that's likely to be required by other crates anyways.