### PR TITLE
Derive Debug and Clone on iterators

### DIFF
--- a/src/btree.rs
+++ b/src/btree.rs
@@ -756,6 +756,7 @@ impl<L, R> Iterator for IntoIter<L, R> {
 /// This struct is created by the [`iter`] method of `BiBTreeMap`.
 ///
 /// [`iter`]: BiBTreeMap::iter
+#[derive(Debug, Clone)]
 pub struct Iter<'a, L, R> {
     inner: btree_map::Iter<'a, Ref<L>, Ref<R>>,
 }
@@ -787,6 +788,7 @@ impl<'a, L, R> Iterator for Iter<'a, L, R> {
 /// This struct is created by the [`left_values`] method of `BiBTreeMap`.
 ///
 /// [`left_values`]: BiBTreeMap::left_values
+#[derive(Debug, Clone)]
 pub struct LeftValues<'a, L, R> {
     inner: btree_map::Iter<'a, Ref<L>, Ref<R>>,
 }
@@ -818,6 +820,7 @@ impl<'a, L, R> Iterator for LeftValues<'a, L, R> {
 /// This struct is created by the [`right_values`] method of `BiBTreeMap`.
 ///
 /// [`right_values`]: BiBTreeMap::right_values
+#[derive(Debug, Clone)]
 pub struct RightValues<'a, L, R> {
     inner: btree_map::Iter<'a, Ref<R>, Ref<L>>,
 }
@@ -849,7 +852,7 @@ impl<'a, L, R> Iterator for RightValues<'a, L, R> {
 /// This struct is created by the [`left_range`] method of `BiBTreeMap`.
 ///
 /// [`left_range`]: BiBTreeMap::left_range
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LeftRange<'a, L, R> {
     inner: btree_map::Range<'a, Ref<L>, Ref<R>>,
 }
@@ -881,7 +884,7 @@ impl<'a, L, R> Iterator for LeftRange<'a, L, R> {
 /// This struct is created by the [`right_range`] method of `BiBTreeMap`.
 ///
 /// [`right_range`]: BiBTreeMap::right_range
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RightRange<'a, L, R> {
     inner: btree_map::Range<'a, Ref<R>, Ref<L>>,
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -833,6 +833,7 @@ impl<L, R> Iterator for IntoIter<L, R> {
 /// This struct is created by the [`iter`] method of `BiHashMap`.
 ///
 /// [`iter`]: BiHashMap::iter
+#[derive(Debug, Clone)]
 pub struct Iter<'a, L, R> {
     inner: hash_map::Iter<'a, Ref<L>, Ref<R>>,
 }
@@ -858,6 +859,7 @@ impl<'a, L, R> Iterator for Iter<'a, L, R> {
 /// This struct is created by the [`left_values`] method of `BiHashMap`.
 ///
 /// [`left_values`]: BiHashMap::left_values
+#[derive(Debug, Clone)]
 pub struct LeftValues<'a, L, R> {
     inner: hash_map::Iter<'a, Ref<L>, Ref<R>>,
 }
@@ -883,6 +885,7 @@ impl<'a, L, R> Iterator for LeftValues<'a, L, R> {
 /// This struct is created by the [`right_values`] method of `BiHashMap`.
 ///
 /// [`right_values`]: BiHashMap::right_values
+#[derive(Debug, Clone)]
 pub struct RightValues<'a, L, R> {
     inner: hash_map::Iter<'a, Ref<R>, Ref<L>>,
 }


### PR DESCRIPTION
`btree_map::Iter` and `hash_map::Iter` are both `Debug + Clone`, no reason why the wrappers aren't