### PR TITLE
Relax trait bounds where possible

### DIFF
--- a/src/btree.rs
+++ b/src/btree.rs
@@ -27,11 +27,7 @@ pub struct BiBTreeMap<L, R> {
     right2left: BTreeMap<Ref<R>, Ref<L>>,
 }
 
-impl<L, R> BiBTreeMap<L, R>
-where
-    L: Ord,
-    R: Ord,
-{
+impl<L, R> BiBTreeMap<L, R> {
     /// Creates an empty `BiBTreeMap`.
     ///
     /// # Examples
@@ -177,7 +173,13 @@ where
             inner: self.right2left.iter(),
         }
     }
+}
 
+impl<L, R> BiBTreeMap<L, R>
+where
+    L: Ord,
+    R: Ord,
+{
     /// Returns a reference to the right value corresponding to the given left
     /// value.
     ///
@@ -610,11 +612,7 @@ where
     }
 }
 
-impl<L, R> Default for BiBTreeMap<L, R>
-where
-    L: Ord,
-    R: Ord,
-{
+impl<L, R> Default for BiBTreeMap<L, R> {
     fn default() -> BiBTreeMap<L, R> {
         BiBTreeMap {
             left2right: BTreeMap::default(),
@@ -625,8 +623,8 @@ where
 
 impl<L, R> Eq for BiBTreeMap<L, R>
 where
-    L: Ord,
-    R: Ord,
+    L: Eq,
+    R: Eq,
 {
 }
 
@@ -647,11 +645,7 @@ where
     }
 }
 
-impl<'a, L, R> IntoIterator for &'a BiBTreeMap<L, R>
-where
-    L: Ord,
-    R: Ord,
-{
+impl<'a, L, R> IntoIterator for &'a BiBTreeMap<L, R> {
     type Item = (&'a L, &'a R);
     type IntoIter = Iter<'a, L, R>;
 
@@ -660,11 +654,7 @@ where
     }
 }
 
-impl<L, R> IntoIterator for BiBTreeMap<L, R>
-where
-    L: Ord,
-    R: Ord,
-{
+impl<L, R> IntoIterator for BiBTreeMap<L, R> {
     type Item = (L, R);
     type IntoIter = IntoIter<L, R>;
 
@@ -699,8 +689,8 @@ where
 
 impl<L, R> PartialEq for BiBTreeMap<L, R>
 where
-    L: Ord,
-    R: Ord,
+    L: PartialEq,
+    R: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         self.left2right == other.left2right
@@ -709,8 +699,8 @@ where
 
 impl<L, R> PartialOrd for BiBTreeMap<L, R>
 where
-    L: Ord,
-    R: Ord,
+    L: PartialOrd,
+    R: PartialOrd,
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.left2right.partial_cmp(&other.left2right)

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -23,11 +23,7 @@ pub struct BiHashMap<L, R, LS = hash_map::RandomState, RS = hash_map::RandomStat
     right2left: HashMap<Ref<R>, Ref<L>, RS>,
 }
 
-impl<L, R> BiHashMap<L, R, hash_map::RandomState, hash_map::RandomState>
-where
-    L: Eq + Hash,
-    R: Eq + Hash,
-{
+impl<L, R> BiHashMap<L, R, hash_map::RandomState, hash_map::RandomState> {
     /// Creates an empty `BiHashMap`.
     ///
     /// # Examples
@@ -62,11 +58,7 @@ where
     }
 }
 
-impl<L, R, LS, RS> BiHashMap<L, R, LS, RS>
-where
-    L: Eq + Hash,
-    R: Eq + Hash,
-{
+impl<L, R, LS, RS> BiHashMap<L, R, LS, RS> {
     /// Returns the number of left-right pairs in the bimap.
     ///
     /// # Examples
@@ -213,13 +205,7 @@ where
     }
 }
 
-impl<L, R, LS, RS> BiHashMap<L, R, LS, RS>
-where
-    L: Eq + Hash,
-    R: Eq + Hash,
-    LS: BuildHasher,
-    RS: BuildHasher,
-{
+impl<L, R, LS, RS> BiHashMap<L, R, LS, RS> {
     /// Creates a new empty `BiHashMap` using `hash_builder_left` to hash left
     /// values and `hash_builder_right` to hash right values.
     ///
@@ -266,7 +252,15 @@ where
             right2left: HashMap::with_capacity_and_hasher(capacity, hash_builder_right),
         }
     }
+}
 
+impl<L, R, LS, RS> BiHashMap<L, R, LS, RS>
+where
+    L: Eq + Hash,
+    R: Eq + Hash,
+    LS: BuildHasher,
+    RS: BuildHasher,
+{
     /// Reserves capacity for at least `additional` more elements to be inserted
     /// in the `BiHashMap`. The collection may reserve more space to avoid
     /// frequent reallocations.
@@ -331,11 +325,11 @@ where
     /// bimap.shrink_to(0);
     /// assert!(bimap.capacity() >= 2);
     /// ```
+
     pub fn shrink_to(&mut self, min_capacity: usize) {
         self.left2right.shrink_to(min_capacity);
         self.right2left.shrink_to(min_capacity);
     }
-
     /// Returns a reference to the right value corresponding to the given left
     /// value.
     ///
@@ -699,10 +693,8 @@ where
 
 impl<L, R, LS, RS> Default for BiHashMap<L, R, LS, RS>
 where
-    L: Eq + Hash,
-    R: Eq + Hash,
-    LS: BuildHasher + Default,
-    RS: BuildHasher + Default,
+    LS: Default,
+    RS: Default,
 {
     fn default() -> BiHashMap<L, R, LS, RS> {
         BiHashMap {
@@ -748,11 +740,7 @@ where
     }
 }
 
-impl<'a, L, R, LS, RS> IntoIterator for &'a BiHashMap<L, R, LS, RS>
-where
-    L: Eq + Hash,
-    R: Eq + Hash,
-{
+impl<'a, L, R, LS, RS> IntoIterator for &'a BiHashMap<L, R, LS, RS> {
     type Item = (&'a L, &'a R);
     type IntoIter = Iter<'a, L, R>;
 
@@ -761,11 +749,7 @@ where
     }
 }
 
-impl<L, R, LS, RS> IntoIterator for BiHashMap<L, R, LS, RS>
-where
-    L: Eq + Hash,
-    R: Eq + Hash,
-{
+impl<L, R, LS, RS> IntoIterator for BiHashMap<L, R, LS, RS> {
     type Item = (L, R);
     type IntoIter = IntoIter<L, R>;
 


### PR DESCRIPTION
Hi,

I had to add trait bounds to a struct containing a `BiHashMap` to be able to derive the `Default` trait. This is usually not necessary, and I found it was because the trait bounds were unecessarily strict.

So I relaxed trait bounds where possible.

