### PR TITLE
Bump hashbrown to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", optional = true }
 [dev-dependencies]
 serde_json = "1.0"
 fnv = "1.0"
-hashbrown = "0.11"
+hashbrown = "0.15"
 
 # This ensures that documentation for optional features is on docs.rs.
 [package.metadata.docs.rs]


### PR DESCRIPTION
I did not notice any incompatibilities with the newer versions so there is no point to keep the old version.
This is going to simplify the packaging for Fedora.